### PR TITLE
Set height for draggable-flow example

### DIFF
--- a/projects/f-examples/draggable-flow/draggable-flow.component.scss
+++ b/projects/f-examples/draggable-flow/draggable-flow.component.scss
@@ -8,3 +8,6 @@
   @include flow-common.node;
 }
 
+f-flow {
+  height: 300px;
+}


### PR DESCRIPTION
## Description

We have to add height to the f-flow component; otherwise, we cannot see it


## Type of change

Please delete options that are not relevant.

- [x] Update of the example documentation.

