### PR TITLE
feat: Added start offset parameter for connection fText

### DIFF
--- a/projects/f-flow/src/f-connection/common/f-connection-base.ts
+++ b/projects/f-flow/src/f-connection/common/f-connection-base.ts
@@ -81,6 +81,8 @@ export abstract class FConnectionBase extends MIXIN_BASE
 
   public abstract fText: string;
 
+  public abstract fTextStartOffset: string;
+
   public abstract fConnectionCenter: ElementRef<HTMLDivElement>;
 
   private penultimatePoint: IPoint = PointExtensions.initialize();

--- a/projects/f-flow/src/f-connection/common/f-connection-text/f-connection-text-path.directive.ts
+++ b/projects/f-flow/src/f-connection/common/f-connection-text/f-connection-text-path.directive.ts
@@ -35,7 +35,7 @@ export class FConnectionTextPathDirective implements IHasHostElement, OnInit {
   }
 
   public ngOnInit(): void {
-    this.hostElement.setAttribute('startOffset', '50%');
+    this.hostElement.setAttribute('startOffset', this.base.fTextStartOffset || '50%');
     this.hostElement.setAttribute('text-anchor', `middle`);
     this.symbolWidth = this.getSymbolWidth(this.base.fText || '');
   }

--- a/projects/f-flow/src/f-connection/common/i-has-connection-text.ts
+++ b/projects/f-flow/src/f-connection/common/i-has-connection-text.ts
@@ -1,4 +1,5 @@
 export interface IHasConnectionText {
 
   fText: string;
+  fTextStartOffset: string;
 }

--- a/projects/f-flow/src/f-connection/f-connection-for-create/f-connection-for-create.component.ts
+++ b/projects/f-flow/src/f-connection/f-connection-for-create/f-connection-for-create.component.ts
@@ -35,10 +35,12 @@ let uniqueId: number = 0;
 })
 export class FConnectionForCreateComponent
   extends FConnectionBase implements AfterViewInit, OnInit, OnDestroy {
+    
+    public override fId: string = `f-connection-for-create-${ uniqueId++ }`;
+    
+    public override fText: string = '';
 
-  public override fId: string = `f-connection-for-create-${ uniqueId++ }`;
-
-  public override fText: string = '';
+    public override fTextStartOffset: string = '';
 
   private _fStartColor: string = 'black';
   @Input()

--- a/projects/f-flow/src/f-connection/f-connection/f-connection.component.ts
+++ b/projects/f-flow/src/f-connection/f-connection/f-connection.component.ts
@@ -52,6 +52,16 @@ export class FConnectionComponent
   @Input('fConnectionId')
   public override fId: string = `f-connection-${ uniqueId++ }`;
 
+  private _fTextStartOffset: string = '';
+  @Input()
+  public override set fTextStartOffset(value: string) {
+    this._fTextStartOffset = value;
+    this.fComponentsStore.componentDataChanged();
+  }
+  public override get fTextStartOffset(): string {
+    return this._fTextStartOffset;
+  }
+
   private _fText: string = '';
   @Input()
   public override set fText(value: string) {

--- a/projects/f-flow/src/f-connection/f-snap-connection/f-snap-connection.component.ts
+++ b/projects/f-flow/src/f-connection/f-snap-connection/f-snap-connection.component.ts
@@ -32,10 +32,12 @@ let uniqueId: number = 0;
 })
 export class FSnapConnectionComponent
   extends FConnectionBase implements AfterViewInit, OnInit, OnDestroy {
-
+  
   public override fId: string = `f-snap-connection-${ uniqueId++ }`;
 
   public override fText: string = '';
+
+  public override fTextStartOffset: string = '';
 
   private _fStartColor: string = 'black';
   @Input()


### PR DESCRIPTION
## Description
Previously, we hardcodedly set our fText's startOffset with 50%. As its not an css property we can not manually update using css.
We added support for dynamically positioning fText by passing an extra property fTextStartOffset for the f-connection. The default value is set to 50%. Can be chaged based on users need.
Fixes #95 

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

- Manually tested

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
