### PR TITLE
fix: update @foblex/drag-toolkit to version 1.1.1 and increment packa…

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -22,7 +22,7 @@
         "@angular/ssr": "^18.2.3",
         "@cypress/angular": "^2.1.0",
         "@foblex/2d": "^1.2.1",
-        "@foblex/drag-toolkit": "1.1.0",
+        "@foblex/drag-toolkit": "1.1.1",
         "@foblex/m-render": "2.6.1",
         "@foblex/mediator": "1.1.2",
         "@foblex/platform": "1.0.4",
@@ -2863,9 +2863,9 @@
       }
     },
     "node_modules/@foblex/drag-toolkit": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@foblex/drag-toolkit/-/drag-toolkit-1.1.0.tgz",
-      "integrity": "sha512-vkI0CDUTY3pYz2dNSgca2rr4KZQTrkfPJMkj8pEhLvWZL6LlvtYdED+e4JNK9Wiqhvz0v8lmUZD5uFM6zYF0vg==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@foblex/drag-toolkit/-/drag-toolkit-1.1.1.tgz",
+      "integrity": "sha512-9MspuSvjPp5satQw1AOXPPmu8G6cS3gycPQ9GL91m3k4Kw9z2nvWjJAJAa/OD41RBSJZWtykveZ7rafTgsx0gA==",
       "dependencies": {
         "tslib": "^2.3.0"
       }

--- a/package.json
+++ b/package.json
@@ -68,7 +68,7 @@
     "@angular/ssr": "^18.2.3",
     "@cypress/angular": "^2.1.0",
     "@foblex/2d": "^1.2.1",
-    "@foblex/drag-toolkit": "1.1.0",
+    "@foblex/drag-toolkit": "1.1.1",
     "@foblex/m-render": "2.6.1",
     "@foblex/mediator": "1.1.2",
     "@foblex/platform": "1.0.4",

--- a/projects/f-flow/package.json
+++ b/projects/f-flow/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@foblex/flow",
-  "version": "17.5.0",
+  "version": "17.5.1",
   "description": "An Angular library designed to simplify the creation and manipulation of dynamic flow. Provides components for flows, nodes, and connections, automating node manipulation and inter-node connections.",
   "main": "index.js",
   "types": "index.d.ts",
@@ -42,7 +42,7 @@
     "@foblex/platform": "1.0.4",
     "@foblex/mediator": "1.1.2",
     "@foblex/2d": "1.2.1",
-    "@foblex/drag-toolkit": "1.1.0",
+    "@foblex/drag-toolkit": "1.1.1",
     "@foblex/utils": "1.1.1"
   },
   "dependencies": {

--- a/projects/f-flow/schematics/shared/foblex-dependencies.ts
+++ b/projects/f-flow/schematics/shared/foblex-dependencies.ts
@@ -2,6 +2,6 @@ export const FoblexDependencies = [
   { name: '@foblex/platform', version: '^1.0.4' },
   { name: '@foblex/mediator', version: '^1.1.2' },
   { name: '@foblex/2d', version: '^1.2.1' },
-  { name: '@foblex/drag-toolkit', version: '^1.1.0' },
+  { name: '@foblex/drag-toolkit', version: '^1.1.1' },
   { name: '@foblex/utils', version: '^1.1.1' }
 ];


### PR DESCRIPTION
This pull request includes minor version updates for the `@foblex/drag-toolkit` dependency across multiple files and a version bump for the `@foblex/flow` package. These changes ensure consistency and compatibility with the latest features and fixes.

### Dependency Updates:
* Updated `@foblex/drag-toolkit` from version `1.1.0` to `1.1.1` in `package.json` [[1]](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L71-R71) `projects/f-flow/package.json` [[2]](diffhunk://#diff-ae9ff4934b9f116fdd9d575f0c181680c7d61630fd646c51d75db2918b6006d1L45-R45) and `projects/f-flow/schematics/shared/foblex-dependencies.ts` [[3]](diffhunk://#diff-b7d7e3a26c3b17403341b7fd6355e1da3a5ca8705a798ee0b71f3a1b3d24f688L5-R5).

### Package Version Update:
* Bumped the version of the `@foblex/flow` package from `17.5.0` to `17.5.1` in `projects/f-flow/package.json`.