### PR TITLE
Add fOffset and fRadius inputs to the docs of connections

### DIFF
--- a/public/markdown/guides/f-connection-component.md
+++ b/public/markdown/guides/f-connection-component.md
@@ -28,6 +28,10 @@ The **FConnectionComponent** is a component that represents a connection between
 
   - `fTextStartOffset: number;` The offset of the text from the start of the connection. Default: `50%`
 
+  - `fOffset: number;` Minimum length of the connection before a curve can occur. Default: `12`
+
+  - `fRadius: number;` Radius used for curves. Default: `8`
+
 ## Styles
   - `.f-component` A general class applied to all F components for shared styling.
 


### PR DESCRIPTION
I have added `fOffset` and `fRadius` to the docs. Probably not the best description but without any mention of this it took me quite a while to find the option :)