### PR TITLE
fix: resolve drag-and-drop issues on macOS by improving event handling

### DIFF
--- a/projects/f-flow/package.json
+++ b/projects/f-flow/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@foblex/flow",
-  "version": "17.5.6",
+  "version": "17.5.7",
   "description": "An Angular library designed to simplify the creation and manipulation of dynamic flow. Provides components for flows, nodes, and connections, automating node manipulation and inter-node connections.",
   "main": "index.js",
   "types": "index.d.ts",

--- a/projects/f-flow/src/drag-toolkit/event.extensions.ts
+++ b/projects/f-flow/src/drag-toolkit/event.extensions.ts
@@ -6,7 +6,7 @@ export class EventExtensions {
 
     if (EventExtensions.isSupported == null && typeof window !== 'undefined') {
       try {
-        window.addEventListener('test', EventExtensions.emptyListener, { passive: true });
+        window.addEventListener('test', EventExtensions.emptyListener, {passive: true});
         EventExtensions.isSupported = true;
       } catch (e) {
         EventExtensions.isSupported = false;
@@ -21,11 +21,15 @@ export class EventExtensions {
   }
 
   public static activeListener(): boolean | AddEventListenerOptions {
-    return EventExtensions.passiveEventListener({ passive: false });
+    return EventExtensions.passiveEventListener({passive: false});
   }
 
   public static passiveListener(): boolean | AddEventListenerOptions {
-    return EventExtensions.passiveEventListener({ passive: true });
+    return EventExtensions.passiveEventListener({passive: true});
+  }
+
+  public static activeCaptureListener(): boolean | AddEventListenerOptions {
+    return EventExtensions.passiveEventListener({passive: false, capture: true});
   }
 
   public static emptyListener(): Function {


### PR DESCRIPTION
This pull request introduces several updates to the `f-flow` package, focusing on improving the drag-and-drop functionality and adding new event handling capabilities. The most notable changes include adding safeguards against redundant drag events, handling additional pointer and context menu events during drag operations, and extending the event handling utilities.

### Drag-and-Drop Enhancements:

* **Prevent Redundant Drag Events**: Added a check (`this.isDragStarted`) in `DragAndDropBase` to prevent initiating drag operations if a drag is already in progress. This change applies to both mouse and touch events. [[1]](diffhunk://#diff-bcb08c9398315bd201996829eea137eb33d636c97a0c60525fa04ca6d97432aeL53-R57) [[2]](diffhunk://#diff-bcb08c9398315bd201996829eea137eb33d636c97a0c60525fa04ca6d97432aeR68-R89) [[3]](diffhunk://#diff-bcb08c9398315bd201996829eea137eb33d636c97a0c60525fa04ca6d97432aeR100-R109)
* **Pointer and Context Menu Event Handling**: Introduced listeners for `pointercancel` and `contextmenu` events during drag operations to improve user interaction handling. The `contextmenu` event is now prevented when a drag is active. [[1]](diffhunk://#diff-bcb08c9398315bd201996829eea137eb33d636c97a0c60525fa04ca6d97432aeR68-R89) [[2]](diffhunk://#diff-bcb08c9398315bd201996829eea137eb33d636c97a0c60525fa04ca6d97432aeR100-R109) [[3]](diffhunk://#diff-bcb08c9398315bd201996829eea137eb33d636c97a0c60525fa04ca6d97432aeR211-R216)

### Event Handling Utilities:

* **New Active Capture Listener**: Added `activeCaptureListener` to `EventExtensions`, providing a reusable utility for registering non-passive event listeners with capture enabled.

### Version Update:

* **Package Version Increment**: Updated the `f-flow` package version from `17.5.6` to `17.5.7` in `package.json` to reflect the new changes.