### PR TITLE
docs: change 12 to 15 as supported angular version

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ It provides a robust, fully Angular-native foundation to create, customize, and 
 - 🧠 **Event-driven architecture** — React to user interaction via clean APIs
 - 🎨 **Customizable Templates** — Use your own components for nodes and connections
 - 🖱 **Drag, Zoom, Pan** — Smooth canvas navigation for large graphs
-- ⚙️ **SSR + Angular Compatibility** — Works with Angular 12+, SSR, Standalone Components, and Composition API
+- ⚙️ **SSR + Angular Compatibility** — Works with Angular 15+, SSR, Standalone Components, and Composition API
 
 ---
 

--- a/projects/f-flow/README.md
+++ b/projects/f-flow/README.md
@@ -16,7 +16,7 @@
 ## Welcome to Foblex Flow
 
 Foblex Flow is an [Angular](https://angular.dev/) library built to simplify the creation and management of dynamic, interactive flows.
-Whether you're developing complex systems or lightweight visualizations, Foblex Flow provides a robust set of tools to help automate node manipulation and inter-node connections with ease. It's fully compatible with Angular 12+, Server-Side Rendering (SSR), and the Composition API.
+Whether you're developing complex systems or lightweight visualizations, Foblex Flow provides a robust set of tools to help automate node manipulation and inter-node connections with ease. It's fully compatible with Angular 15+, Server-Side Rendering (SSR), and the Composition API.
 
 ### Examples
 

--- a/src/app/home-page/home-page-background/domain/hero-flow.configuration.ts
+++ b/src/app/home-page/home-page-background/domain/hero-flow.configuration.ts
@@ -9,7 +9,7 @@ export const HERO_FLOW_CONFIGURATION: IHeroFlowConfiguration = {
       to: EFConnectableSide.AUTO,
       from: EFConnectableSide.TOP,
       large: true,
-      text: 'Angular 12+'
+      text: 'Angular 15+'
     },
     {
       uid: '2',

--- a/src/app/home.config.ts
+++ b/src/app/home.config.ts
@@ -18,7 +18,7 @@ export const HOME_CONFIGURATION = {
       headline: 'Foblex Flow',
       tagline1: 'Built with Angular',
       tagline2: 'Flow-Chart Library',
-      subDescription: 'Supports Angular 12+, SSR, and Composition API.',
+      subDescription: 'Supports Angular 15+, SSR, and Composition API.',
     }),
     provideBackground(HomePageBackgroundComponent),
     provideImage(HomePageImageComponent),


### PR DESCRIPTION
This PR adjusts all places mentioning supported angular version to 15+ as this version is required since @foblex/flow@17.0.0.