### PR TITLE
fix: wait for progressive virtual render before fLoaded

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "18.1.0",
+  "version": "18.2.1",
   "description": "Angular-native node-based UI library for building node editors, workflow builders, and interactive graph interfaces.",
   "author": "Siarhei Huzarevich",
   "homepage": "https://flow.foblex.com",

--- a/projects/f-flow/package.json
+++ b/projects/f-flow/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@foblex/flow",
-  "version": "18.2.0",
+  "version": "18.2.1",
   "description": "Angular-native node-based UI library for building node editors, workflow builders, and interactive graph interfaces.",
   "main": "index.js",
   "types": "index.d.ts",

--- a/projects/f-flow/src/f-flow/f-flow.component.spec.ts
+++ b/projects/f-flow/src/f-flow/f-flow.component.spec.ts
@@ -1,0 +1,51 @@
+import { Component } from '@angular/core';
+import { fakeAsync, TestBed, tick } from '@angular/core/testing';
+import { By } from '@angular/platform-browser';
+import { FFlowModule } from '../f-flow.module';
+import { FComponentsStore } from '../f-storage';
+import { FFlowComponent } from './f-flow.component';
+
+@Component({
+  standalone: true,
+  imports: [FFlowModule],
+  template: `
+    <f-flow (fLoaded)="loadedIds.push($event)">
+      <f-canvas></f-canvas>
+    </f-flow>
+  `,
+})
+class HostComponent {
+  public loadedIds: string[] = [];
+}
+
+describe('FFlowComponent', () => {
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [HostComponent],
+    }).compileComponents();
+  });
+
+  it('should wait for progressive rendering before emitting fLoaded', fakeAsync(() => {
+    const fixture = TestBed.createComponent(HostComponent);
+    fixture.detectChanges();
+
+    const flowDebugElement = fixture.debugElement.query(By.directive(FFlowComponent));
+    const store = flowDebugElement.injector.get(FComponentsStore);
+
+    store.beginProgressiveRender();
+    store.emitNodeChanges();
+
+    tick(300);
+    fixture.detectChanges();
+
+    expect(fixture.componentInstance.loadedIds).toEqual([]);
+
+    store.endProgressiveRender();
+
+    tick(300);
+    fixture.detectChanges();
+
+    expect(fixture.componentInstance.loadedIds.length).toBe(1);
+    expect(fixture.componentInstance.loadedIds[0]).toContain('f-flow-');
+  }));
+});

--- a/projects/f-flow/src/f-flow/f-flow.component.ts
+++ b/projects/f-flow/src/f-flow/f-flow.component.ts
@@ -36,9 +36,9 @@ import { FMediator } from '@foblex/mediator';
 import { F_DRAGGABLE_PROVIDERS, FDraggableDataContext } from '../f-draggable';
 import {
   EmitConnectionsChangesRequest,
+  FComponentsStore,
   F_STORAGE_PROVIDERS,
   ListenConnectionsChangesRequest,
-  ListenNodesChangesRequest,
 } from '../f-storage';
 import { BrowserService } from '@foblex/platform';
 import { afterNextPaint, debounceTime, FChannelHub, notifyOnStart, takeOne } from '../reactivity';
@@ -75,6 +75,7 @@ export class FFlowComponent extends FFlowBase implements OnInit, AfterContentIni
   private readonly _destroyRef = inject(DestroyRef);
   private readonly _mediator = inject(FMediator);
   private readonly _browser = inject(BrowserService);
+  private readonly _componentsStore = inject(FComponentsStore);
   private readonly _cache = inject(F_CACHE_OPTIONS);
   private readonly _injector = inject(Injector);
   private readonly _worker = inject(FConnectionWorker);
@@ -111,11 +112,17 @@ export class FFlowComponent extends FFlowBase implements OnInit, AfterContentIni
   }
 
   private _listenNodesChanges(): void {
-    this._mediator
-      .execute<FChannelHub>(new ListenNodesChangesRequest())
+    new FChannelHub(
+      this._componentsStore.nodesChanges$,
+      this._componentsStore.progressiveRenderChanges$,
+    )
       .pipe(notifyOnStart(), debounceTime(SORT_ITEM_LAYERS_DEBOUNCE_MS), afterNextPaint())
       .listen(this._destroyRef, () => {
         if (this._mediator.execute(new IsDragStartedRequest())) {
+          return;
+        }
+
+        if (this._componentsStore.hasPendingProgressiveRender) {
           return;
         }
 

--- a/projects/f-flow/src/f-storage/f-components-store.ts
+++ b/projects/f-flow/src/f-storage/f-components-store.ts
@@ -27,12 +27,19 @@ export class FComponentsStore {
   public readonly nodesChanges$ = new FChannel();
   private _nodesRevision = 0;
 
+  public readonly progressiveRenderChanges$ = new FChannel();
+  private _pendingProgressiveRenderCount = 0;
+
   public get connectionsRevision(): number {
     return this._connectionsRevision;
   }
 
   public get nodesRevision(): number {
     return this._nodesRevision;
+  }
+
+  public get hasPendingProgressiveRender(): boolean {
+    return this._pendingProgressiveRenderCount > 0;
   }
 
   public get flowHost(): HTMLElement {
@@ -67,6 +74,20 @@ export class FComponentsStore {
   public emitConnectionChanges(): void {
     this._connectionsRevision++;
     this.connectionsChanges$.notify();
+  }
+
+  public beginProgressiveRender(): void {
+    this._pendingProgressiveRenderCount++;
+    this.progressiveRenderChanges$.notify();
+  }
+
+  public endProgressiveRender(): void {
+    if (!this._pendingProgressiveRenderCount) {
+      return;
+    }
+
+    this._pendingProgressiveRenderCount--;
+    this.progressiveRenderChanges$.notify();
   }
 
   public transformChanged(): void {

--- a/projects/f-flow/src/f-virtual/f-virtual-for.ts
+++ b/projects/f-flow/src/f-virtual/f-virtual-for.ts
@@ -5,10 +5,12 @@ import {
   Input,
   NgZone,
   OnChanges,
+  OnDestroy,
   SimpleChanges,
   TemplateRef,
   ViewContainerRef,
 } from '@angular/core';
+import { FComponentsStore } from '../f-storage';
 
 interface FVirtualContext<T> {
   $implicit: T;
@@ -19,15 +21,18 @@ interface FVirtualContext<T> {
   selector: '[fVirtualFor][fVirtualForOf]',
   standalone: true,
 })
-export class FVirtualFor<T> implements OnChanges {
+export class FVirtualFor<T> implements OnChanges, OnDestroy {
   @Input() fVirtualForOf: readonly T[] = [];
   @Input() fVirtualForTrackBy?: (index: number, item: T) => unknown;
 
   private readonly _vc = inject(ViewContainerRef);
   private readonly _tpl = inject<TemplateRef<FVirtualContext<T>>>(TemplateRef);
   private readonly _zone = inject(NgZone);
+  private readonly _componentsStore = inject(FComponentsStore, { optional: true });
 
   private _views: EmbeddedViewRef<FVirtualContext<T>>[] = [];
+  private _rafId: number | null = null;
+  private _isProgressiveRenderActive = false;
 
   ngOnChanges(changes: SimpleChanges): void {
     if (changes['fVirtualForOf']) {
@@ -36,7 +41,17 @@ export class FVirtualFor<T> implements OnChanges {
     }
   }
 
+  ngOnDestroy(): void {
+    this._reset();
+  }
+
   private _reset(): void {
+    if (this._rafId !== null) {
+      cancelAnimationFrame(this._rafId);
+      this._rafId = null;
+    }
+
+    this._finishProgressiveRender();
     this._vc.clear();
     this._views.length = 0;
   }
@@ -44,6 +59,7 @@ export class FVirtualFor<T> implements OnChanges {
   private _renderProgressively(): void {
     const FRAME_BUDGET = 10; // ms
     let index = 0;
+    this._startProgressiveRender();
 
     this._zone.runOutsideAngular(() => {
       const pump = () => {
@@ -62,11 +78,34 @@ export class FVirtualFor<T> implements OnChanges {
         }
 
         if (index < this.fVirtualForOf.length) {
-          requestAnimationFrame(pump);
+          this._rafId = requestAnimationFrame(pump);
+
+          return;
         }
+
+        this._rafId = null;
+        this._finishProgressiveRender();
       };
 
-      requestAnimationFrame(pump);
+      this._rafId = requestAnimationFrame(pump);
     });
+  }
+
+  private _startProgressiveRender(): void {
+    if (this._isProgressiveRenderActive) {
+      return;
+    }
+
+    this._isProgressiveRenderActive = true;
+    this._componentsStore?.beginProgressiveRender();
+  }
+
+  private _finishProgressiveRender(): void {
+    if (!this._isProgressiveRenderActive) {
+      return;
+    }
+
+    this._isProgressiveRenderActive = false;
+    this._componentsStore?.endProgressiveRender();
   }
 }


### PR DESCRIPTION
## Summary
- delay `fLoaded` until progressive rendering via `*fVirtualFor` has finished
- track in-flight progressive renders in `FComponentsStore`
- add a regression spec for the public `fLoaded` contract

## Problem
When projected nodes are rendered progressively with `*fVirtualFor`, `(fLoaded)` could fire before all nodes were in the DOM. Consumers calling `fitToScreen()` from `(fLoaded)` then computed bounds too early and started with the wrong viewport.

Fixes #281
Related to #266

## Testing
- `npm run test -- --watch=false --browsers=ChromeHeadless`
