### PR TITLE
release(18.6.1): fix label perf (#304) + group position race (#305)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to this project will be documented in this file. See [standa
 
 ## Unreleased
 
+## [18.6.1](https://github.com/Foblex/f-flow/compare/v18.6.0...v18.6.1) (2026-05-14)
+
 ### Fixes
 
 - **connection-content:** stop reading `getBoundingClientRect()` inside the label placement loop. Each `fConnectionContent` directive now installs a `ResizeObserver` on its host element and reports its size via the cached value, instead of forcing a synchronous layout flush per label on every connection redraw. At a few hundred labelled connections the old read/write loop became O(N²) browser work and froze drag; the hot path now performs zero DOM reads on label hosts. Fixes [#304](https://github.com/Foblex/f-flow/issues/304).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file. See [standa
 
 ## Unreleased
 
+### Fixes
+
+- **reflow:** stop the reflow orchestrator from planning shifts against half-applied node state. When `withReflowOnResize()` is paired with a group that uses `fAutoSizeToFitChildren` and the graph is swapped in (e.g. by replacing the `@for` source), several children of the group used to collapse onto a single DOM-measured position because the orchestrator built its plan from candidates whose `position()` signal had not yet been mirrored into `_position`. Candidates whose model and mirror are out of sync are now skipped for that tick — the orchestrator resumes once the next coherent state arrives. Fixes [#305](https://github.com/Foblex/f-flow/issues/305).
+
 ## [18.6.0](https://github.com/Foblex/f-flow/compare/v18.5.0...v18.6.0) (2026-04-26)
 
 ### Highlights

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ All notable changes to this project will be documented in this file. See [standa
 
 ### Fixes
 
+- **connection-content:** stop reading `getBoundingClientRect()` inside the label placement loop. Each `fConnectionContent` directive now installs a `ResizeObserver` on its host element and reports its size via the cached value, instead of forcing a synchronous layout flush per label on every connection redraw. At a few hundred labelled connections the old read/write loop became O(N²) browser work and froze drag; the hot path now performs zero DOM reads on label hosts. Fixes [#304](https://github.com/Foblex/f-flow/issues/304).
 - **reflow:** stop the reflow orchestrator from planning shifts against half-applied node state. When `withReflowOnResize()` is paired with a group that uses `fAutoSizeToFitChildren` and the graph is swapped in (e.g. by replacing the `@for` source), several children of the group used to collapse onto a single DOM-measured position because the orchestrator built its plan from candidates whose `position()` signal had not yet been mirrored into `_position`. Candidates whose model and mirror are out of sync are now skipped for that tick — the orchestrator resumes once the next coherent state arrives. Fixes [#305](https://github.com/Foblex/f-flow/issues/305).
 
 ## [18.6.0](https://github.com/Foblex/f-flow/compare/v18.5.0...v18.6.0) (2026-04-26)

--- a/libs/f-flow/package.json
+++ b/libs/f-flow/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@foblex/flow",
-  "version": "18.6.0",
+  "version": "18.6.1",
   "description": "Angular-native node-based UI library for building node editors, workflow builders, and interactive graph interfaces.",
   "main": "index.js",
   "types": "index.d.ts",

--- a/libs/f-flow/src/f-connection-v2/components/connection-content/connection-content-perf.spec.ts
+++ b/libs/f-flow/src/f-connection-v2/components/connection-content/connection-content-perf.spec.ts
@@ -1,0 +1,115 @@
+import { Component, signal } from '@angular/core';
+import { TestBed } from '@angular/core/testing';
+import { FFlowModule } from '@foblex/flow';
+
+// Regression for https://github.com/Foblex/f-flow/issues/304.
+//
+// `PolylineContentPlace.compute()` runs inside a tight loop in
+// `ConnectionContentLayoutEngine.layout()` and is interleaved with
+// `style.transform` writes for every label. Reading the label size via
+// `getBoundingClientRect()` on every iteration forced a synchronous
+// layout flush per label and caused O(N²) browser work at a few
+// hundred labelled connections — drag-time stalled and labels appeared
+// one-by-one across many frames.
+//
+// The fix moves the size lookup off the hot path: each label installs
+// a `ResizeObserver` once and reports the cached size via
+// `IPolylineContent.measureSize()`. This spec proves the hot path
+// performs zero direct DOM reads on label hosts across repeated
+// redraws — if anyone reintroduces a `getBoundingClientRect()` call
+// inside the placement loop, the count would grow with the redraw
+// count and this expectation would fail.
+
+@Component({
+  standalone: true,
+  imports: [FFlowModule],
+  template: `
+    <f-flow style="display: block; width: 800px; height: 600px">
+      <f-canvas>
+        <div
+          fNode
+          fNodeId="src"
+          [fNodePosition]="source()"
+          fNodeOutput
+          fOutputId="src-out"
+          style="width: 80px; height: 40px"
+        >
+          src
+        </div>
+        @for (target of targets(); track target.id) {
+          <div
+            fNode
+            [fNodeId]="target.id"
+            [fNodePosition]="target.position"
+            fNodeInput
+            [fInputId]="target.id"
+            style="width: 60px; height: 30px"
+          >
+            {{ target.id }}
+          </div>
+          <f-connection fOutputId="src-out" [fInputId]="target.id" fType="straight">
+            <div fConnectionContent>{{ target.id }}</div>
+          </f-connection>
+        }
+      </f-canvas>
+    </f-flow>
+  `,
+})
+class HostComponent {
+  public readonly source = signal({ x: 0, y: 0 });
+  public readonly targets = signal(
+    Array.from({ length: 8 }, (_, i) => ({
+      id: `target-${i + 1}`,
+      position: { x: 200 + (i % 4) * 100, y: 100 + Math.floor(i / 4) * 80 },
+    })),
+  );
+}
+
+describe('Issue #304 — fConnectionContent layout performance', () => {
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [HostComponent],
+    }).compileComponents();
+  });
+
+  it('does not call getBoundingClientRect on label hosts during repeated source-position redraws', async () => {
+    const fixture = TestBed.createComponent(HostComponent);
+    fixture.detectChanges();
+
+    // Let mount + the ResizeObserver's first delivery populate the
+    // per-label size cache before we start counting.
+    for (let i = 0; i < 5; i++) {
+      await new Promise<void>((r) => setTimeout(r, 30));
+      fixture.detectChanges();
+    }
+
+    const originalGetBoundingClientRect = Element.prototype.getBoundingClientRect;
+    let labelHostReads = 0;
+    Element.prototype.getBoundingClientRect = function () {
+      if (
+        typeof (this as HTMLElement).className === 'string' &&
+        (this as HTMLElement).className.includes('f-connection-content')
+      ) {
+        labelHostReads++;
+      }
+
+      return originalGetBoundingClientRect.call(this);
+    };
+
+    try {
+      // 30 redraws — the planner runs `compute()` and the engine
+      // applies `style.transform` on every iteration. Pre-fix, this
+      // produced one `getBoundingClientRect` call per label per
+      // redraw; post-fix the count must stay at zero.
+      for (let i = 1; i <= 30; i++) {
+        fixture.componentInstance.source.set({ x: i * 4, y: i * 2 });
+        fixture.detectChanges();
+        await new Promise<void>((r) => setTimeout(r, 16));
+      }
+    } finally {
+      Element.prototype.getBoundingClientRect = originalGetBoundingClientRect;
+    }
+
+    expect(labelHostReads).toBe(0);
+  });
+});

--- a/libs/f-flow/src/f-connection-v2/components/connection-content/models/f-connection-content-base.ts
+++ b/libs/f-flow/src/f-connection-v2/components/connection-content/models/f-connection-content-base.ts
@@ -1,4 +1,5 @@
-import { ElementRef, inject, InjectionToken, Signal } from '@angular/core';
+import { DestroyRef, ElementRef, inject, InjectionToken, Signal } from '@angular/core';
+import { ISize } from '@foblex/2d';
 import { IPolylineContent, PolylineContentAlign } from '../utils';
 
 export const F_CONNECTION_CONTENT = new InjectionToken<FConnectionContentBase>(
@@ -11,6 +12,41 @@ export abstract class FConnectionContentBase implements IPolylineContent {
    * Used internally for positioning calculations.
    */
   public readonly hostElement = inject(ElementRef<HTMLElement>).nativeElement;
+
+  // ResizeObserver-backed size cache. Avoids `getBoundingClientRect`
+  // inside the placement loop, where one DOM read per label per redraw
+  // forced a synchronous layout flush and dominated drag-time at a few
+  // hundred labelled connections (issue #304). The observer also keeps
+  // the cache correct when the label content actually resizes.
+  //
+  // The initial size is populated by the observer's first asynchronous
+  // delivery — calling `getBoundingClientRect()` from the constructor
+  // re-introduces the thrashing during Angular CD when many labels
+  // mount in the same tick. Until the first delivery, the size stays
+  // at zero; the only visible effect is that the edge-guard does not
+  // push labels away from path endpoints on the very first frame.
+  // Labels at `position` ≠ 0 / 1 are unaffected.
+  private _cachedSize: ISize = { width: 0, height: 0 };
+  private _observer: ResizeObserver | null = null;
+
+  constructor() {
+    if (typeof ResizeObserver === 'undefined') {
+      return;
+    }
+
+    this._observer = new ResizeObserver((entries) => {
+      for (const entry of entries) {
+        const rect = entry.contentRect;
+        this._cachedSize = { width: rect.width, height: rect.height };
+      }
+    });
+    this._observer.observe(this.hostElement);
+
+    inject(DestroyRef).onDestroy(() => {
+      this._observer?.disconnect();
+      this._observer = null;
+    });
+  }
 
   /**
    * Position along the connection.
@@ -40,4 +76,8 @@ export abstract class FConnectionContentBase implements IPolylineContent {
    * - `'along'` — aligned along the path (tangent).
    */
   public abstract align: Signal<PolylineContentAlign>;
+
+  public measureSize(): ISize {
+    return this._cachedSize;
+  }
 }

--- a/libs/f-flow/src/f-connection-v2/components/connection-content/utils/i-polyline-content.ts
+++ b/libs/f-flow/src/f-connection-v2/components/connection-content/utils/i-polyline-content.ts
@@ -1,4 +1,5 @@
 import { Signal } from '@angular/core';
+import { ISize } from '@foblex/2d';
 import { PolylineContentAlign } from './polyline-content-align';
 
 /** Domain contract for content item to be placed along the path. */
@@ -10,4 +11,16 @@ export interface IPolylineContent {
   align: Signal<PolylineContentAlign>;
 
   hostElement: HTMLElement;
+
+  /**
+   * Returns the latest measured size of the content's host element.
+   *
+   * Implementations cache the size and refresh it via a
+   * `ResizeObserver` rather than reading the DOM on every call —
+   * placement runs in a tight loop interleaved with style writes, so
+   * a per-call `getBoundingClientRect()` forces a synchronous layout
+   * flush per label and turns drag into a layout-thrashing storm at
+   * a few hundred labels (see issue #304).
+   */
+  measureSize(): ISize;
 }

--- a/libs/f-flow/src/f-connection-v2/components/connection-content/utils/polyline-content-place.ts
+++ b/libs/f-flow/src/f-connection-v2/components/connection-content/utils/polyline-content-place.ts
@@ -1,5 +1,5 @@
 import { IPolylineContent } from './i-polyline-content';
-import { IPoint, RectExtensions } from '@foblex/2d';
+import { IPoint } from '@foblex/2d';
 import { PolylineSampler } from './polyline-sampler';
 import { PolylineContentAlign } from './polyline-content-align';
 
@@ -23,7 +23,7 @@ export class PolylineContentPlace {
     const y = point.y + normal.y * lateral;
 
     // Edge guard
-    const projectedSize = this._sizeAlongDirection(content.hostElement, tangent);
+    const projectedSize = this._sizeAlongDirection(content, tangent);
     const halfExtent = projectedSize * 0.5;
 
     const distanceFromStart = progress * sampler.totalLength;
@@ -69,10 +69,15 @@ export class PolylineContentPlace {
     return { x, y };
   }
 
-  private _sizeAlongDirection(element: HTMLElement, dir: IPoint): number {
-    const rect = RectExtensions.fromElement(element);
+  // Reads the size via `content.measureSize()` — a ResizeObserver-backed
+  // cache. This loop runs interleaved with `style.transform` writes for
+  // every label, so a `getBoundingClientRect()` here would force a
+  // synchronous layout flush per label and stall drag at a few hundred
+  // labelled connections (issue #304).
+  private _sizeAlongDirection(content: IPolylineContent, dir: IPoint): number {
+    const size = content.measureSize();
 
-    return Math.abs(dir.x) * rect.width + Math.abs(dir.y) * rect.height;
+    return Math.abs(dir.x) * size.width + Math.abs(dir.y) * size.height;
   }
 
   private _normalize180(angleDeg: number): number {

--- a/libs/f-flow/src/plugins/layout/f-reflow-on-resize/group-children-position-race.spec.ts
+++ b/libs/f-flow/src/plugins/layout/f-reflow-on-resize/group-children-position-race.spec.ts
@@ -1,0 +1,177 @@
+import { Component, signal } from '@angular/core';
+import { TestBed } from '@angular/core/testing';
+import { By } from '@angular/platform-browser';
+import { FFlowComponent, FFlowModule, provideFFlow } from '@foblex/flow';
+import { withReflowOnResize } from './with-reflow-on-resize';
+
+// Chrome reports "ResizeObserver loop completed with undelivered
+// notifications" as a global error when nested resize observers fire —
+// in this spec, fit-to-children moves the group, which triggers another
+// observer tick. Karma elevates that into a test failure even though it
+// is a harmless warning. Wrap `window.onerror` so the original Karma /
+// Jasmine handler never sees it. Other errors fall through unchanged.
+const previousOnError = window.onerror;
+window.onerror = function (message, source, lineno, colno, error) {
+  if (typeof message === 'string' && message.includes('ResizeObserver loop')) {
+    return true;
+  }
+  if (typeof previousOnError === 'function') {
+    return previousOnError.call(window, message, source, lineno, colno, error);
+  }
+
+  return false;
+};
+
+// Regression for https://github.com/Foblex/f-flow/issues/305.
+//
+// When `provideFFlow(withReflowOnResize())` is active AND a group uses
+// `fAutoSizeToFitChildren`, swapping the graph leaves several children of
+// the group stuck at the same DOM-measured position instead of their
+// assigned `[fNodePosition]`. The signature in the original report is a
+// fractional `(x, y)` shared by multiple siblings — clear evidence that
+// the values came from DOM rect measurement, not from input.
+//
+// Trigger combo (both must be on):
+//   - `withReflowOnResize(...)` in `provideFFlow(...)`.
+//   - `fAutoSizeToFitChildren` on at least one `<f-group>` that holds
+//     children whose `[fNodePosition]` we assert against.
+
+interface IReproNode {
+  id: string;
+  parentId: string | null;
+  position: { x: number; y: number };
+}
+
+const PARENT_GROUP = 'hostParentGroup';
+const CHILDREN_GROUP = 'hostChildrenGroup';
+
+const SMALL_NODES: IReproNode[] = [
+  { id: 'small-a', parentId: PARENT_GROUP, position: { x: 225, y: 84 } },
+  { id: 'small-b', parentId: null, position: { x: 825, y: 200 } },
+  { id: 'small-c', parentId: CHILDREN_GROUP, position: { x: 1425, y: 200 } },
+];
+
+// Positions verbatim from issue #305 Dagre output.
+const BIG_NODES: IReproNode[] = [
+  { id: 'n1', parentId: PARENT_GROUP, position: { x: 225, y: 84 } },
+  { id: 'n6', parentId: PARENT_GROUP, position: { x: 225, y: 242 } },
+  { id: 'n7', parentId: CHILDREN_GROUP, position: { x: 1425, y: 953 } },
+  { id: 'n24', parentId: CHILDREN_GROUP, position: { x: 1425, y: 795 } },
+  { id: 'n31', parentId: CHILDREN_GROUP, position: { x: 1425, y: 637 } },
+  { id: 'n32', parentId: CHILDREN_GROUP, position: { x: 1425, y: 479 } },
+  { id: 'n114', parentId: PARENT_GROUP, position: { x: 225, y: 400 } },
+  { id: 'n201', parentId: CHILDREN_GROUP, position: { x: 1425, y: 321 } },
+  { id: 'n202', parentId: CHILDREN_GROUP, position: { x: 1425, y: 163 } },
+  { id: 'n217', parentId: null, position: { x: 825, y: 558 } },
+  { id: 'n218', parentId: PARENT_GROUP, position: { x: 225, y: 558 } },
+  { id: 'n219', parentId: PARENT_GROUP, position: { x: 225, y: 716 } },
+  { id: 'n226', parentId: PARENT_GROUP, position: { x: 225, y: 874 } },
+  { id: 'n227', parentId: PARENT_GROUP, position: { x: 225, y: 1032 } },
+];
+
+@Component({
+  standalone: true,
+  imports: [FFlowModule],
+  providers: [provideFFlow(withReflowOnResize())],
+  // ResizeObserver and the reflow orchestrator both depend on real
+  // measured box geometry — give the host a concrete size so children
+  // produce non-zero rects.
+  template: `
+    <f-flow style="display: block; width: 1600px; height: 1200px">
+      <f-canvas>
+        <div
+          fGroup
+          fGroupId="hostParentGroup"
+          fAutoSizeToFitChildren
+          [fGroupPosition]="{ x: 0, y: 0 }"
+          style="width: 200px; height: 100px"
+        >
+          Parent
+        </div>
+        <div
+          fGroup
+          fGroupId="hostChildrenGroup"
+          fAutoSizeToFitChildren
+          [fGroupPosition]="{ x: 0, y: 0 }"
+          style="width: 200px; height: 100px"
+        >
+          Children
+        </div>
+        @for (n of nodes(); track n.id) {
+          <div
+            fNode
+            [fNodeId]="n.id"
+            [fNodePosition]="n.position"
+            [fNodeParentId]="n.parentId ?? null"
+            style="width: 120px; height: 80px"
+          >
+            {{ n.id }}
+          </div>
+        }
+      </f-canvas>
+    </f-flow>
+  `,
+})
+class HostComponent {
+  public readonly nodes = signal<IReproNode[]>(SMALL_NODES);
+}
+
+async function settle(
+  fixture: ReturnType<typeof TestBed.createComponent<HostComponent>>,
+): Promise<void> {
+  // Long enough to drain the ResizeObserver loop and the orchestrator's
+  // internal debounces. Short rAFs cause the browser to emit a
+  // "ResizeObserver loop completed with undelivered notifications"
+  // warning that Karma elevates into a test failure.
+  for (let i = 0; i < 3; i++) {
+    fixture.detectChanges();
+    await new Promise<void>((r) => setTimeout(r, 80));
+  }
+  fixture.detectChanges();
+}
+
+describe('Issue #305 — group children position race', () => {
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [HostComponent],
+    }).compileComponents();
+  });
+
+  it('keeps each assigned position after a small → big graph swap', async () => {
+    const fixture = TestBed.createComponent(HostComponent);
+    fixture.detectChanges();
+    await settle(fixture);
+
+    fixture.componentInstance.nodes.set(BIG_NODES);
+    fixture.detectChanges();
+    await settle(fixture);
+
+    const flow = fixture.debugElement.query(By.directive(FFlowComponent))
+      .componentInstance as FFlowComponent;
+    const state = flow.getState();
+
+    const byInputId = new Map<string, { x: number; y: number }>();
+    for (const node of state.nodes) {
+      const inputId = node.fInputs?.[0]?.id;
+      if (inputId) {
+        byInputId.set(inputId, node.position);
+      } else if (node.id) {
+        byInputId.set(node.id, node.position);
+      }
+    }
+
+    const broken: { id: string; expected: unknown; got: unknown }[] = [];
+    for (const expected of BIG_NODES) {
+      const got = byInputId.get(expected.id);
+      if (
+        !got ||
+        Math.abs(got.x - expected.position.x) > 0.5 ||
+        Math.abs(got.y - expected.position.y) > 0.5
+      ) {
+        broken.push({ id: expected.id, expected: expected.position, got });
+      }
+    }
+
+    expect(broken).toEqual([]);
+  });
+});

--- a/libs/f-flow/src/plugins/layout/f-reflow-on-resize/orchestrator/f-reflow-orchestrator.ts
+++ b/libs/f-flow/src/plugins/layout/f-reflow-on-resize/orchestrator/f-reflow-orchestrator.ts
@@ -180,8 +180,20 @@ export class FReflowOrchestrator {
     return result;
   }
 
+  // We only emit a shift plan for nodes whose model signal matches
+  // `_position`. A mismatch means the node is mid-flight — either its
+  // `positionChanges()` effect has not yet mirrored the latest signal
+  // into `_position`, or an internal write (fit-to-children) advanced
+  // `_position` ahead of the model. Planning against a half-applied
+  // state poisons every candidate read from DOM and propagates one
+  // measured rect onto many siblings (issue #305). Skipping the rect
+  // makes the orchestrator wait until the next coherent tick.
   private _safeGetRect(node: FNodeBase): IRect | null {
     if (!node.hostElement) {
+      return null;
+    }
+    const modelPos = node.position();
+    if (modelPos.x !== node._position.x || modelPos.y !== node._position.y) {
       return null;
     }
     try {

--- a/libs/f-layout/dagre/package.json
+++ b/libs/f-layout/dagre/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@foblex/flow-dagre-layout",
-  "version": "18.6.0",
+  "version": "18.6.1",
   "description": "Dagre layout engine adapter for Foblex Flow.",
   "main": "index.js",
   "types": "index.d.ts",

--- a/libs/f-layout/elk/package.json
+++ b/libs/f-layout/elk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@foblex/flow-elk-layout",
-  "version": "18.6.0",
+  "version": "18.6.1",
   "description": "ELK.js layout engine adapter for Foblex Flow.",
   "main": "index.js",
   "types": "index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "18.6.0",
+  "version": "18.6.1",
   "description": "Angular-native node-based UI library for building node editors, workflow builders, and interactive graph interfaces.",
   "author": "Siarhei Huzarevich",
   "homepage": "https://flow.foblex.com",


### PR DESCRIPTION
## Summary

- **fix(connection-content)** — close [#304](https://github.com/Foblex/f-flow/issues/304). `fConnectionContent` no longer reads `getBoundingClientRect()` on every redraw. Each label installs a `ResizeObserver` once and reports its size from a cached value via the new `IPolylineContent.measureSize()`. The placement loop in `PolylineContentPlace.compute()` was interleaving DOM reads with `style.transform` writes per iteration, which forced a synchronous layout flush per label and turned drag at a few hundred labelled connections into O(N²) browser work.
- **fix(reflow)** — close [#305](https://github.com/Foblex/f-flow/issues/305). The reflow orchestrator no longer plans shifts against half-applied node state. When `withReflowOnResize()` is paired with `fAutoSizeToFitChildren` on a group and the graph is swapped, candidates whose `position()` signal had not yet been mirrored into `_position` used to feed one stale DOM rect to every sibling, collapsing them onto the same fractional point. Such candidates are now skipped for the tick.
- **chore(release)** — bump `@foblex/flow`, `@foblex/flow-dagre-layout`, `@foblex/flow-elk-layout`, and the root workspace to `18.6.1`; CHANGELOG section pinned under the new release header.

## Test plan

- [x] New regression spec `libs/f-flow/.../connection-content-perf.spec.ts` — 30 source-position redraws produce 0 `getBoundingClientRect()` calls on label hosts.
- [x] New regression spec `libs/f-flow/.../group-children-position-race.spec.ts` — small → big graph swap with `withReflowOnResize() + fAutoSizeToFitChildren` keeps every child at its assigned position.
- [x] Full `nx test f-flow` suite green (138 + 1 + 1 specs).
- [x] `nx lint f-flow` clean.
- [x] Manual verification in the portal stress example: dragging "Move me" at 1000 labelled edges is smooth after the fix; was unusably slow before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)