### PR TITLE
feat(zoom): add fScrollPan and fPinchStep inputs to FZoomDirective

### DIFF
--- a/apps/f-flow-portal/public/llms-full.txt
+++ b/apps/f-flow-portal/public/llms-full.txt
@@ -628,6 +628,8 @@ Selector: `f-canvas[fZoom]`
 | fZoomMaximum | number | 4 | Maximum zoom scale |
 | fZoomStep | number | 0.1 | Wheel zoom step |
 | fZoomDblClickStep | number | 0.5 | Double-click zoom step |
+| fScrollPan | boolean | false | Two-finger scroll pans canvas |
+| fPinchStep | number | 0 | Pinch zoom step; 0 uses fZoomStep |
 
 #### Methods
 

--- a/apps/f-flow-portal/public/llms.txt
+++ b/apps/f-flow-portal/public/llms.txt
@@ -37,7 +37,7 @@
 - [fDragHandle Directive](https://flow.foblex.com/docs/f-drag-handle-directive): Drag-start surface
 - [fResizeHandle Directive](https://flow.foblex.com/docs/f-resize-handle-directive): Resize handles with directions
 - [fRotateHandle Directive](https://flow.foblex.com/docs/f-rotate-handle-directive): Rotation handles
-- [fZoom Directive](https://flow.foblex.com/docs/f-zoom-directive): Wheel, pinch, and double-click zoom
+- [fZoom Directive](https://flow.foblex.com/docs/f-zoom-directive): Wheel, pinch, double-click zoom, and optional two-finger trackpad pan
 - [f-minimap Component](https://flow.foblex.com/docs/f-minimap-component): Overview navigator
 - [f-background Component](https://flow.foblex.com/docs/f-background-component): Canvas background patterns
 - [f-selection-area](https://flow.foblex.com/docs/f-selection-area-component): Rectangle multi-select

--- a/apps/f-flow-portal/public/markdown/guides/interaction/f-zoom-directive.md
+++ b/apps/f-flow-portal/public/markdown/guides/interaction/f-zoom-directive.md
@@ -3,7 +3,7 @@
 **Selector:** `f-canvas[fZoom]`  
 **Class:** `FZoomDirective`
 
-`FZoomDirective` adds wheel, double-click, and **pinch-to-zoom** (multitouch) capabilities, and exposes a small imperative zoom API.
+`FZoomDirective` adds wheel, double-click, **pinch-to-zoom** (multitouch), and optional two-finger pan capabilities, and exposes a small imperative zoom API.
 
 ## Why / Use cases
 
@@ -36,6 +36,8 @@ When used in conjunction with [`fDraggable`](f-draggable-directive), `fZoom` aut
 - `fZoomMaximum: number;` Default: `4`. Maximum zoom scale.
 - `fZoomStep: number;` Default: `0.1`. Zoom step for wheel interaction.
 - `fZoomDblClickStep: number;` Default: `0.5`. Zoom step for double-click interaction.
+- `fScrollPan: boolean;` Default: `false`. When enabled, two-finger scroll pans the canvas instead of zooming. Pinch gesture continues to zoom.
+- `fPinchStep: number;` Default: `0`. Zoom step for pinch gestures. When `0`, falls back to `fZoomStep`.
 
 ### Outputs
 

--- a/libs/f-examples/extensions/zoom/example.html
+++ b/libs/f-examples/extensions/zoom/example.html
@@ -1,5 +1,5 @@
 <f-flow fDraggable (fLoaded)="onLoaded()">
-  <f-canvas [fZoom]="isZoomEnabled">
+  <f-canvas [fZoom]="isZoomEnabled" [fScrollPan]="isScrollPanEnabled">
     <f-connection fOutputId="output1" fInputId="input1" fBehavior="floating"></f-connection>
     <div fNode [fNodePosition]="{ x: 0, y: 0 }" fDragHandle>
       <div fNodeOutput fOutputId="output1" class="right"></div>
@@ -16,5 +16,8 @@
   <button class="f-button primary" (click)="onZoomOut()">Zoom Out</button>
   <f-checkbox [checked]="isZoomEnabled" (change)="onZoomOnMouseWheelChanged($event)"
     >Enable Wheel and Dbl Click</f-checkbox
+  >
+  <f-checkbox [checked]="isScrollPanEnabled" (change)="onScrollPanChanged($event)"
+    >Two-finger pan</f-checkbox
   >
 </f-toolbar>

--- a/libs/f-examples/extensions/zoom/example.ts
+++ b/libs/f-examples/extensions/zoom/example.ts
@@ -18,6 +18,7 @@ export class Example {
   protected fZoom!: FZoomDirective;
 
   protected isZoomEnabled: boolean = true;
+  protected isScrollPanEnabled: boolean = false;
 
   protected onLoaded(): void {
     this.fCanvas.resetScaleAndCenter(false);
@@ -33,5 +34,9 @@ export class Example {
 
   protected onZoomOnMouseWheelChanged(checked: boolean): void {
     this.isZoomEnabled = checked;
+  }
+
+  protected onScrollPanChanged(checked: boolean): void {
+    this.isScrollPanEnabled = checked;
   }
 }

--- a/libs/f-flow/src/f-zoom/f-zoom.directive.ts
+++ b/libs/f-flow/src/f-zoom/f-zoom.directive.ts
@@ -32,7 +32,12 @@ import {
   RegisterPluginInstanceRequest,
   RemovePluginInstanceRequest,
 } from '../f-storage';
-import { normalizeWheelStep, resolveWheelDelta } from './wheel-zoom.utils';
+import {
+  isGestureWheelEvent,
+  isTrackpadScrollEvent,
+  normalizeWheelStep,
+  resolveWheelDelta,
+} from './wheel-zoom.utils';
 
 @Directive({
   selector: 'f-canvas[fZoom]',
@@ -68,6 +73,12 @@ export class FZoomDirective extends FZoomBase implements OnInit, AfterViewInit, 
 
   @Input({ alias: 'fZoomDblClickStep', transform: numberAttribute })
   public override dblClickStep: number = 0.5;
+
+  @Input({ transform: booleanAttribute })
+  public fScrollPan: boolean = false;
+
+  @Input({ alias: 'fPinchStep', transform: numberAttribute })
+  public pinchStep: number = 0;
 
   private get _flowHost(): HTMLElement {
     return this._store.flowHost;
@@ -124,6 +135,12 @@ export class FZoomDirective extends FZoomBase implements OnInit, AfterViewInit, 
       return;
     }
 
+    if (this.fScrollPan && isTrackpadScrollEvent(event)) {
+      this._panByWheel(event);
+
+      return;
+    }
+
     const delta = resolveWheelDelta(event);
     if (delta === 0) {
       return;
@@ -143,12 +160,27 @@ export class FZoomDirective extends FZoomBase implements OnInit, AfterViewInit, 
   };
 
   private _normalizeWheelStep(event: WheelEvent, delta: number): number {
-    return normalizeWheelStep(event, delta, this.step);
+    const step = isGestureWheelEvent(event) && this.pinchStep > 0 ? this.pinchStep : this.step;
+
+    return normalizeWheelStep(event, delta, step);
   }
 
   private _calculateDirection(delta: number): number {
     return delta > 0 ? EFZoomDirection.ZOOM_OUT : EFZoomDirection.ZOOM_IN;
   }
+
+  private _panByWheel(event: WheelEvent): void {
+    const canvas = this._canvas;
+    if (!canvas) {
+      return;
+    }
+
+    const pos = canvas.transform.position;
+    canvas._setPosition(PointExtensions.initialize(pos.x - event.deltaX, pos.y - event.deltaY));
+    canvas.redraw();
+    canvas.emitCanvasChangeEvent();
+  }
+
   private _onDoubleClick = (event: MouseEvent) => {
     if (!isValidEventTrigger(event, this.fDblClickTrigger)) {
       return;

--- a/libs/f-flow/src/f-zoom/wheel-zoom.utils.spec.ts
+++ b/libs/f-flow/src/f-zoom/wheel-zoom.utils.spec.ts
@@ -1,4 +1,9 @@
-import { isGestureWheelEvent, normalizeWheelStep, resolveWheelDelta } from './wheel-zoom.utils';
+import {
+  isGestureWheelEvent,
+  isTrackpadScrollEvent,
+  normalizeWheelStep,
+  resolveWheelDelta,
+} from './wheel-zoom.utils';
 
 describe('wheel zoom utils', () => {
   it('should resolve the dominant wheel axis delta', () => {
@@ -40,6 +45,25 @@ describe('wheel zoom utils', () => {
 
     expect(normalizeWheelStep(event, 6, 0.1)).toBeCloseTo(0.01, 6);
     expect(normalizeWheelStep(event, 1, 0.1)).toBeCloseTo(1 / 600, 6);
+  });
+
+  it('should detect trackpad two-finger scroll (pan intent)', () => {
+    expect(
+      isTrackpadScrollEvent(createWheelEvent({ deltaMode: WheelEvent.DOM_DELTA_PIXEL })),
+    ).toBeTrue();
+    expect(
+      isTrackpadScrollEvent(
+        createWheelEvent({ ctrlKey: true, deltaMode: WheelEvent.DOM_DELTA_PIXEL }),
+      ),
+    ).toBeFalse();
+    expect(
+      isTrackpadScrollEvent(
+        createWheelEvent({ metaKey: true, deltaMode: WheelEvent.DOM_DELTA_PIXEL }),
+      ),
+    ).toBeFalse();
+    expect(
+      isTrackpadScrollEvent(createWheelEvent({ deltaMode: WheelEvent.DOM_DELTA_LINE })),
+    ).toBeFalse();
   });
 
   it('should ignore tiny gesture-wheel noise and cap large pinch deltas', () => {

--- a/libs/f-flow/src/f-zoom/wheel-zoom.utils.ts
+++ b/libs/f-flow/src/f-zoom/wheel-zoom.utils.ts
@@ -19,6 +19,15 @@ export function isGestureWheelEvent(event: WheelEvent): boolean {
   return (event.ctrlKey || event.metaKey) && event.deltaMode === WheelEvent.DOM_DELTA_PIXEL;
 }
 
+/**
+ * Returns true for trackpad two-finger scroll events (pan intent).
+ * Pinch-to-zoom arrives as DOM_DELTA_PIXEL + ctrlKey; plain trackpad scroll
+ * arrives as DOM_DELTA_PIXEL without any modifier key.
+ */
+export function isTrackpadScrollEvent(event: WheelEvent): boolean {
+  return event.deltaMode === WheelEvent.DOM_DELTA_PIXEL && !event.ctrlKey && !event.metaKey;
+}
+
 function normalizeMouseWheelStep(delta: number, step: number): number {
   const intensity = Math.abs(delta) / 100;
   const normalized = clamp(intensity, DEFAULT_WHEEL_INTENSITY_MIN, DEFAULT_WHEEL_INTENSITY_MAX);


### PR DESCRIPTION
## Summary

- `fScrollPan: boolean` — when enabled, two-finger scroll on a trackpad pans the canvas instead of zooming. Opt-in, default `false`.
- `fPinchStep: number` — separate zoom step for pinch gestures. When `0`, falls back to `fZoomStep`. Default `0`.

## Related Issue

Closes #312

## Problem

On MacBook and other precision trackpads, two-finger scroll triggers zoom instead of panning the canvas. There was also no way to tune pinch-to-zoom speed independently from mouse wheel zoom — both shared `fZoomStep`, but pinch gestures have very different sensitivity.

## Scope

- `libs/f-flow/src/f-zoom/f-zoom.directive.ts` — two new inputs, wheel routing logic
- `libs/f-flow/src/f-zoom/wheel-zoom.utils.ts` — new `isTrackpadScrollEvent` utility
- `libs/f-flow/src/f-zoom/wheel-zoom.utils.spec.ts` — unit tests
- `libs/f-examples/extensions/zoom/` — checkbox added to the live example
- `apps/f-flow-portal/public/` — docs updated

## Public API Impact

Two new opt-in inputs on `FZoomDirective`. No breaking changes. Default behavior is unchanged.

| Input | Type | Default |
|---|---|---|
| `fScrollPan` | `boolean` | `false` |
| `fPinchStep` | `number` | `0` |

## Documentation and Examples

- `f-zoom-directive.md` — new inputs documented
- `llms-full.txt` and `llms.txt` — updated
- Zoom example — "Two-finger pan" checkbox added

## Testing

All 140 existing tests pass. New unit test added for `isTrackpadScrollEvent` covering pixel-mode detection and modifier key exclusions.
